### PR TITLE
Support "application/graphql" Content-Type header

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -75,7 +75,7 @@ export default request
 
 async function getResult(response: Response): Promise<any> {
   const contentType = response.headers.get('Content-Type')
-  if (contentType && contentType.startsWith('application/json')) {
+  if (contentType && (contentType.startsWith('application/json') || contentType.startsWith('application/graphql'))) {
     return response.json()
   } else {
     return response.text()


### PR DESCRIPTION
Ran into some issues with certain GraphQL servers that do not return a JSON Content-Type header.