### PR TITLE
Add raw request method

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ const query = `{
     }
   }
 }`
-  
+
 request('https://api.graph.cool/simple/v1/movies', query).then(data => console.log(data))
 ```
 
@@ -44,7 +44,7 @@ request(endpoint, query, variables).then(data => console.log(data))
 
 // ... or create a GraphQL client instance to send requests
 const client = new GraphQLClient(endpoint, { headers: {} })
-client.request(query, variables).then(data => console.log(data)) 
+client.request(query, variables).then(data => console.log(data))
 ```
 
 ## Examples
@@ -69,7 +69,7 @@ const query = `{
   }
 }`
 
-client.request(query).then(data => console.log(data)) 
+client.request(query).then(data => console.log(data))
 ```
 
 ### Passing more options to fetch
@@ -91,7 +91,7 @@ const query = `{
   }
 }`
 
-client.request(query).then(data => console.log(data)) 
+client.request(query).then(data => console.log(data))
 ```
 
 ### Using variables
@@ -145,7 +145,7 @@ const query = `{
     }
   }
 }`
-  
+
 request('my-endpoint', query).then(data => console.log(data))
 ```
 
@@ -173,6 +173,26 @@ const query = `{
 }`
 
 client.request(query).then(data => console.log(data))
+```
+
+### Receiving a raw response
+
+The `request` method will return the `data` or `errors` key from the response.
+If you need to access the `extensions` key you can use the `rawRequest` method:
+
+```js
+import { rawRequest } from 'graphql-request'
+
+const query = `{
+  Movie(title: "Inception") {
+    releaseDate
+    actors {
+      name
+    }
+  }
+}`
+
+rawRequest('my-endpoint', query).then(({data, extensions}) => console.log(data, extensions))
 ```
 
 ### More examples coming soon...

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,7 @@ export class GraphQLClient {
   async rawRequest<T extends any>(
     query: string,
     variables?: Variables,
-  ): Promise<{ data?: T, extensions?: any, errors?: GraphQLError }> {
+  ): Promise<{ data?: T, extensions?: any, errors?: GraphQLError[] }> {
     const { headers, ...others } = this.options
 
     const body = JSON.stringify({
@@ -97,7 +97,7 @@ export async function rawRequest<T extends any>(
   url: string,
   query: string,
   variables?: Variables,
-): Promise<{ data?: T, extensions?: any, errors?: GraphQLError }> {
+): Promise<{ data?: T, extensions?: any, errors?: GraphQLError[] }> {
   const client = new GraphQLClient(url)
 
   return client.rawRequest<T>(query, variables)

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { ClientError, Headers, Options, Variables } from './types'
+import { ClientError, GraphQLError, Headers, Options, Variables } from './types'
 export { ClientError } from './types'
 import 'cross-fetch/polyfill'
 
@@ -14,7 +14,7 @@ export class GraphQLClient {
   async rawRequest<T extends any>(
     query: string,
     variables?: Variables,
-  ): Promise<T> {
+  ): Promise<{ data?: T, extensions?: any, errors?: GraphQLError }> {
     const { headers, ...others } = this.options
 
     const body = JSON.stringify({
@@ -97,7 +97,7 @@ export async function rawRequest<T extends any>(
   url: string,
   query: string,
   variables?: Variables,
-): Promise<T> {
+): Promise<{ data?: T, extensions?: any, errors?: GraphQLError }> {
   const client = new GraphQLClient(url)
 
   return client.rawRequest<T>(query, variables)

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,6 +25,7 @@ export interface GraphQLError {
 export interface GraphQLResponse {
   data?: any
   errors?: GraphQLError[]
+  extensions?: any
   status: number
   [key: string]: any
 }


### PR DESCRIPTION
Closes #62

This implements a new `rawRequest` method to allow clients to access all of [the defined GraphQL response keys](http://facebook.github.io/graphql/October2016/#sec-Response-Format): `data`, `errors` and `extensions`. With the `request` method it is not possible to access the `extensions` key if it is included in the response.

The only difference to the `request` method is, instead of [returning `result.data`](https://github.com/graphcool/graphql-request/blob/master/src/index.ts#L35), `rawRequest` simply returns the raw `result` object (which may include `data` and `extensions`).

Because of the similarities, there is currently a lot of repetition. @schickling let me know if this is OK or if you'd like to abstract the repeated logic. `request` could just call `rawRequest` and return `result.data`.